### PR TITLE
Add resources configuration options to all jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,15 @@ Kubernetes is the default store backend. `consul`, `etcdv2` or `etcdv3` can also
 | `serviceMonitor.namespace`              | Set to use a different value than the release namespace for deploying the ServiceMonitor object | `nil`       |
 | `serviceMonitor.interval`               | Set to use a different value than the default Prometheus scrape interval | `nil`                              |
 | `serviceMonitor.scrapeTimeout`          | Set to use a different value than the default Prometheus scrape timeout | `nil`                               |
-| `job.autoCreateCluster`                 | Set to `false` to force-disable auto-cluster-creation which may clear pre-existing postgres db data | `true`  |
-| `job.autoUpdateClusterSpec`             | Set to `false` to force-disable auto-cluster-spec-update | `true`                                             |
+| `job.autoCreateCluster.enabled`         | Set to `false` to force-disable auto-cluster-creation which may clear pre-existing postgres db data | `true`  |
+| `job.autoCreateCluster.resources`       | Job autoCreaterCluster containers resources    | `{}`                                                         |
+| `job.autoCreateCluster.initContainers.resources` | Job autoCreaterCluster initContainers resources | `{}`                                               |
+| `job.initdbScripts.enabled`             | Set to `false` to force-disable initdb script execution | `true`                                              |
+| `job.initdbScripts.resources`           | Job initdbScripts containers resources         | `{}`                                                         |
+| `job.initdbScripts.initContainers.resources` | Job autoUpdateClusterSpec initContainers resources | `{}`                                                |
+| `job.autoUpdateClusterSpec.enabled`     | Set to `false` to force-disable auto-cluster-spec-update | `true`                                             |
+| `job.autoUpdateClusterSpec.resources`   | Job autoUpdateClusterSpec containers resources | `{}`                                                         |
+| `job.autoUpdateClusterSpec.initContainers.resources` | Job autoUpdateClusterSpec initContainers resources | `{}`                                        |
 | `job.annotations`                       | Annotations for Jobs, the value is evaluated as a template. | `{}`                                            |
 | `clusterSpec`                           | Stolon cluster spec [reference](https://github.com/sorintlab/stolon/blob/master/doc/cluster_spec.md) | `{}`   |
 | `tls.enabled`                           | Enable tls support to postgresql               | `false`                                                      |

--- a/templates/hooks/create-cluster-job.yaml
+++ b/templates/hooks/create-cluster-job.yaml
@@ -1,4 +1,4 @@
-{{ if and .Release.IsInstall .Values.job.autoCreateCluster }}
+{{ if and .Release.IsInstall .Values.job.autoCreateCluster.enabled }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -30,6 +30,8 @@ spec:
           image: "{{ .Values.etcdImage.repository }}:{{ .Values.etcdImage.tag }}"
           imagePullPolicy: {{ .Values.etcdImage.pullPolicy }}
           command: ["sh", "-c", "while ! etcdctl --endpoints {{ .Values.store.endpoints }} cluster-health; do sleep 1 && echo -n .; done"]
+          resources:
+            {{- toYaml .Values.job.autoCreateCluster.initContainers.resources | nindent 12 }}
   {{- end }}
       containers:
         - name: {{ template "stolon.fullname" . }}-create-cluster
@@ -47,4 +49,6 @@ spec:
             {{- end }}
             - --yes
             - '{ "initMode": "new", {{- range $key, $value := .Values.clusterSpec }} {{ $key | quote }}: {{ if typeIs "string" $value }} {{ $value | quote }} {{ else }} {{ $value }} {{ end }}, {{- end }} {{ if .Values.tls.enabled }} "pgParameters": {{- $pgParameters := .Values.pgParameters -}}{{ $all_init := set $pgParameters "ssl" "on" }}{{ $all_init := set $all_init "ssl_cert_file" "/certs/serverCrt.crt" }} {{ $all_init := set $all_init "ssl_key_file" "/certs/serverKey.key" }}{{ $all_init := set $all_init "ssl_ca_file" "/certs/rootCa.crt" }}{{ toJson $all_init }}{{ else }}"pgParameters": {{ toJson .Values.pgParameters }} {{ end}} }'
+          resources:
+            {{- toYaml .Values.job.autoCreateCluster.resources | nindent 12 }}
 {{ end }}

--- a/templates/hooks/init-db-job.yaml
+++ b/templates/hooks/init-db-job.yaml
@@ -60,6 +60,8 @@ spec:
           - name: HOST
             value: {{ template "stolon.fullname" . }}-proxy
         command: ["/bin/bash", "-e", "/tmp/sql-script/create_script.sh"]
+        resources:
+          {{- toYaml .Values.job.initdbScripts.resources | nindent 10 }}
         volumeMounts:
           - mountPath: "/tmp/sql-script"
             readOnly: true
@@ -73,4 +75,6 @@ spec:
         - name: wait-for-database
           image: jwilder/dockerize
           command: ['dockerize', '-timeout', '30s', '-wait', 'tcp://{{ template "stolon.fullname" . }}-proxy:5432']
+          resources:
+            {{- toYaml .Values.job.initdbScripts.initContainers.resources | nindent 12 }}
 {{- end }}

--- a/templates/hooks/update-cluster-spec-job.yaml
+++ b/templates/hooks/update-cluster-spec-job.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.job.autoUpdateClusterSpec }}
+{{ if .Values.job.autoUpdateClusterSpec.enabled }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -30,6 +30,8 @@ spec:
           image: "{{ .Values.etcdImage.repository }}:{{ .Values.etcdImage.tag }}"
           imagePullPolicy: {{ .Values.etcdImage.pullPolicy }}
           command: ["sh", "-c", "while ! etcdctl --endpoints {{ .Values.store.endpoints }} cluster-health; do sleep 1 && echo -n .; done"]
+          resources:
+            {{- toYaml .Values.job.autoUpdateClusterSpec.initContainers.resources | nindent 12 }}
   {{- end }}
       containers:
         - name: {{ template "stolon.fullname" . }}-update-cluster-spec
@@ -47,4 +49,6 @@ spec:
             {{- end }}
             - -p
             - '{ {{- range $key, $value := .Values.clusterSpec }} {{ $key | quote }}: {{ if typeIs "string" $value }} {{ $value | quote }} {{ else }} {{ $value }} {{ end }}, {{- end }} {{ if .Values.tls.enabled }}"pgParameters": {{- $pgParameters := .Values.pgParameters -}}{{ $all := set $pgParameters "ssl" "on" }}{{ $all := set $all "ssl_cert_file" "/certs/serverCrt.crt" }} {{ $all := set $all "ssl_key_file" "/certs/serverKey.key" }}{{ $all := set $all "ssl_ca_file" "/certs/rootCa.crt" }}{{ toJson $all }} {{ else }}"pgParameters": {{- $pgParameters := .Values.pgParameters -}}{{ $all := set $pgParameters "ssl" "off" }}{{ $all := set $all "ssl_cert_file" nil }} {{ $all := set $all "ssl_key_file" nil }}{{ $all := set $all "ssl_ca_file" nil }}{{ toJson $all }}{{ end}}}'
+          resources:
+            {{- toYaml .Values.job.autoUpdateClusterSpec.resources | nindent 12 }}
 {{ end }}

--- a/values.yaml
+++ b/values.yaml
@@ -90,8 +90,21 @@ serviceMonitor:
   # scrapeTimeout: 10s
 
 job:
-  autoCreateCluster: true
-  autoUpdateClusterSpec: true
+  autoCreateCluster:
+    enabled: true
+    resources: {}
+    initContainers:
+      resources: {}
+  initdbScripts:
+    enabled: true
+    resources: {}
+    initContainers:
+      resources: {}
+  autoUpdateClusterSpec:
+    enabled: true
+    resources: {}
+    initContainers:
+      resources: {}
   annotations: {}
 
 clusterSpec: {}
@@ -198,6 +211,6 @@ sentinel:
 ## i.e. you can create tablespace directory here.
 ##
 # nodePostStartScript:
-#  postStartScript.sh: |
-#    #!/bin/bash
+#   postStartScript.sh: |
+#     #!/bin/bash
 #     echo "Do something."


### PR DESCRIPTION
This patch adds resources configuration options to all job pods.

Some production grade clusters force to set resources to be able to calculate
quotas correctly. So it is crucial to be able to set those resources an all
pods.

This patch include breaking changes, because it changes the structure of the
values.

Closes #2

Signed-off-by: Sven Haardiek <sven.haardiek@uni-muenster.de>