### PR TITLE
Fine tune and split role permissions

### DIFF
--- a/templates/role.yaml
+++ b/templates/role.yaml
@@ -13,9 +13,22 @@ rules:
     - ""
   resources:
     - pods
-    - endpoints
+  verbs:
+    - get
+    - patch
+    - list
+- apiGroups:
+    - ""
+  resources:
     - configmaps
+  verbs:
+    - get
+    - create
+    - update
+- apiGroups:
+    - ""
+  resources:
     - events
   verbs:
-    - "*"
+    - create
 {{- end -}}


### PR DESCRIPTION
This patch updates the role permissions and not allow "*" on all resources
needed by stolon.

This fixes two problems:

* The "*" verb is not allowed for every user in every cluster.
  For example the Default ClusterRole `admin` shipped with kubernetes is not
  allowed to use this verb. So this is replaced with proper verbs.
* With the current permissions stolon is able to add new pods and also delete
  all pods in its namespace. With this patch it is at least reduced to updates.

Of course there could be done more, but I think this is a good start.

Signed-off-by: Sven Haardiek <sven.haardiek@uni-muenster.de>