### PR TITLE
Introduce Option for Security Context

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,13 +66,22 @@ Kubernetes is the default store backend. `consul`, `etcdv2` or `etcdv3` can also
 | `serviceMonitor.scrapeTimeout`          | Set to use a different value than the default Prometheus scrape timeout | `nil`                               |
 | `job.autoCreateCluster.enabled`         | Set to `false` to force-disable auto-cluster-creation which may clear pre-existing postgres db data | `true`  |
 | `job.autoCreateCluster.resources`       | Job autoCreaterCluster containers resources    | `{}`                                                         |
+| `job.autoCreateCluster.podSecurityContext` | Job autoCreaterCluster Security Context for the Pod | `{}`                                                 |
+| `job.autoCreateCluster.securityContext` | Job autoCreaterCluster Security Context for the Containers | `{}`                                             |
 | `job.autoCreateCluster.initContainers.resources` | Job autoCreaterCluster initContainers resources | `{}`                                               |
+| `job.autoCreateCluster.initContainers.securityContext` | Job autoCreaterCluster Security Context for the initContainers | `{}`                          |
 | `job.initdbScripts.enabled`             | Set to `false` to force-disable initdb script execution | `true`                                              |
 | `job.initdbScripts.resources`           | Job initdbScripts containers resources         | `{}`                                                         |
-| `job.initdbScripts.initContainers.resources` | Job autoUpdateClusterSpec initContainers resources | `{}`                                                |
+| `job.initdbScripts.podSecurityContext` | Job initdbScripts Security Context for the Pod | `{}`                                                          |
+| `job.initdbScripts.securityContext` | Job initdbScripts Security Context for the Containers | `{}`                                                      |
+| `job.initdbScripts.initContainers.resources` | Job initdbScripts initContainers resources | `{}`                                                        |
+| `job.initdbScripts.initContainers.securityContext` | Job initdbScripts Security Context for the initContainers | `{}`                                   |
 | `job.autoUpdateClusterSpec.enabled`     | Set to `false` to force-disable auto-cluster-spec-update | `true`                                             |
 | `job.autoUpdateClusterSpec.resources`   | Job autoUpdateClusterSpec containers resources | `{}`                                                         |
+| `job.autoUpdateClusterSpec.podSecurityContext` | Job autoUpdateClusterSpec Security Context for the Pod | `{}`                                          |
+| `job.autoUpdateClusterSpec.securityContext` | Job autoUpdateClusterSpec Security Context for the Containers | `{}`                                      |
 | `job.autoUpdateClusterSpec.initContainers.resources` | Job autoUpdateClusterSpec initContainers resources | `{}`                                        |
+| `job.autoUpdateClusterSpec.initContainers.securityContext` | Job autoUpdateClusterSpec Security Context for the initContainers | `{}`                   |
 | `job.annotations`                       | Annotations for Jobs, the value is evaluated as a template. | `{}`                                            |
 | `clusterSpec`                           | Stolon cluster spec [reference](https://github.com/sorintlab/stolon/blob/master/doc/cluster_spec.md) | `{}`   |
 | `tls.enabled`                           | Enable tls support to postgresql               | `false`                                                      |
@@ -83,8 +92,9 @@ Kubernetes is the default store backend. `consul`, `etcdv2` or `etcdv3` can also
 | `keeper.uid_prefix`                     | Keeper prefix name                             | `keeper`                                                     |
 | `keeper.replicaCount`                   | Number of keeper nodes                         | `2`                                                          |
 | `keeper.resources`                      | Keeper resource requests/limit                 | `{}`                                                         |
+| `keeper.podSecurityContext`             | Keeper Security Context for the Pod            | `{}`                                                         |
+| `keeper.securityContext`                | Keeper Security Context for the Containers     | `{}`                                                         |
 | `keeper.priorityClassName`              | Keeper priorityClassName                       | `nil`                                                        |
-| `keeper.fsGroup`                        | Keeper securityContext fsGroup, do not set if pg9 or 10 | ``                                                  |
 | `keeper.nodeSelector`                   | Node labels for keeper pod assignment          | `{}`                                                         |
 | `keeper.affinity`                       | Affinity settings for keeper pod assignment    | `{}`                                                         |
 | `keeper.tolerations`                    | Toleration labels for keeper pod assignment    | `[]`                                                         |
@@ -97,6 +107,8 @@ Kubernetes is the default store backend. `consul`, `etcdv2` or `etcdv3` can also
 | `keeper.extraEnv`                       | Extra [environment variables](https://github.com/sorintlab/stolon/blob/master/doc/commands_invocation.md#commands-invocation) for keeper | `[]` |
 | `proxy.replicaCount`                    | Number of proxy nodes                          | `2`                                                          |
 | `proxy.resources`                       | Proxy resource requests/limit                  | `{}`                                                         |
+| `proxy.podSecurityContext`              | Proxy Security Context for the Pod             | `{}`                                                         |
+| `proxy.securityContext`                 | Proxy Security Context for the Containers      | `{}`                                                         |
 | `proxy.priorityClassName`               | Proxy priorityClassName                        | `nil`                                                        |
 | `proxy.nodeSelector`                    | Node labels for proxy pod assignment           | `{}`                                                         |
 | `proxy.affinity`                        | Affinity settings for proxy pod assignment     | `{}`                                                         |
@@ -107,6 +119,8 @@ Kubernetes is the default store backend. `consul`, `etcdv2` or `etcdv3` can also
 | `proxy.extraEnv`                        | Extra [environment variables](https://github.com/sorintlab/stolon/blob/master/doc/commands_invocation.md#commands-invocation) for proxy | `[]` |
 | `sentinel.replicaCount`                 | Number of sentinel nodes                       | `2`                                                          |
 | `sentinel.resources`                    | Sentinel resource requests/limit               | `{}`                                                         |
+| `sentinel.podSecurityContext`           | Sentinel Security Context for the Pod          | `{}`                                                         |
+| `sentinel.securityContext`              | Sentinel Security Context for the Containers   | `{}`                                                         |
 | `sentinel.priorityClassName`            | Sentinel priorityClassName                     | `nil`                                                        |
 | `sentinel.nodeSelector`                 | Node labels for sentinel pod assignment        | `{}`                                                         |
 | `sentinel.affinity`                     | Affinity settings for sentinel pod assignment  | `{}`                                                         |

--- a/templates/hooks/create-cluster-job.yaml
+++ b/templates/hooks/create-cluster-job.yaml
@@ -24,6 +24,10 @@ spec:
     spec:
       restartPolicy: OnFailure
       serviceAccountName: {{ template "stolon.serviceAccountName" . }}
+      {{- with .Values.job.autoCreateCluster.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
   {{- if eq .Values.store.backend "etcdv2" "etcdv3" }}
       initContainers:
         - name: {{ .Chart.Name }}-etcd-wait
@@ -32,6 +36,10 @@ spec:
           command: ["sh", "-c", "while ! etcdctl --endpoints {{ .Values.store.endpoints }} cluster-health; do sleep 1 && echo -n .; done"]
           resources:
             {{- toYaml .Values.job.autoCreateCluster.initContainers.resources | nindent 12 }}
+          {{- with .Values.job.autoCreateCluster.initContainers.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
   {{- end }}
       containers:
         - name: {{ template "stolon.fullname" . }}-create-cluster
@@ -51,4 +59,8 @@ spec:
             - '{ "initMode": "new", {{- range $key, $value := .Values.clusterSpec }} {{ $key | quote }}: {{ if typeIs "string" $value }} {{ $value | quote }} {{ else }} {{ $value }} {{ end }}, {{- end }} {{ if .Values.tls.enabled }} "pgParameters": {{- $pgParameters := .Values.pgParameters -}}{{ $all_init := set $pgParameters "ssl" "on" }}{{ $all_init := set $all_init "ssl_cert_file" "/certs/serverCrt.crt" }} {{ $all_init := set $all_init "ssl_key_file" "/certs/serverKey.key" }}{{ $all_init := set $all_init "ssl_ca_file" "/certs/rootCa.crt" }}{{ toJson $all_init }}{{ else }}"pgParameters": {{ toJson .Values.pgParameters }} {{ end}} }'
           resources:
             {{- toYaml .Values.job.autoCreateCluster.resources | nindent 12 }}
+          {{- with .Values.job.autoCreateCluster.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
 {{ end }}

--- a/templates/hooks/init-db-job.yaml
+++ b/templates/hooks/init-db-job.yaml
@@ -35,6 +35,10 @@ spec:
 {{- end }}
     spec:
       restartPolicy: Never
+      {{- with .Values.job.initdbScripts.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - name: create-database-job
         image: 'postgres'
@@ -62,6 +66,10 @@ spec:
         command: ["/bin/bash", "-e", "/tmp/sql-script/create_script.sh"]
         resources:
           {{- toYaml .Values.job.initdbScripts.resources | nindent 10 }}
+        {{- with .Values.job.initdbScripts.securityContext }}
+        securityContext:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         volumeMounts:
           - mountPath: "/tmp/sql-script"
             readOnly: true
@@ -77,4 +85,8 @@ spec:
           command: ['dockerize', '-timeout', '30s', '-wait', 'tcp://{{ template "stolon.fullname" . }}-proxy:5432']
           resources:
             {{- toYaml .Values.job.initdbScripts.initContainers.resources | nindent 12 }}
+          {{- with .Values.job.initdbScripts.initContainers.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
 {{- end }}

--- a/templates/hooks/update-cluster-spec-job.yaml
+++ b/templates/hooks/update-cluster-spec-job.yaml
@@ -24,6 +24,10 @@ spec:
     spec:
       restartPolicy: OnFailure
       serviceAccountName: {{ template "stolon.serviceAccountName" . }}
+      {{- with .Values.job.autoUpdateClusterSpec.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
   {{- if eq .Values.store.backend "etcdv2" "etcdv3" }}
       initContainers:
         - name: {{ .Chart.Name }}-etcd-wait
@@ -32,6 +36,10 @@ spec:
           command: ["sh", "-c", "while ! etcdctl --endpoints {{ .Values.store.endpoints }} cluster-health; do sleep 1 && echo -n .; done"]
           resources:
             {{- toYaml .Values.job.autoUpdateClusterSpec.initContainers.resources | nindent 12 }}
+          {{- with .Values.job.autoUpdateClusterSpec.initContainers.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
   {{- end }}
       containers:
         - name: {{ template "stolon.fullname" . }}-update-cluster-spec
@@ -51,4 +59,8 @@ spec:
             - '{ {{- range $key, $value := .Values.clusterSpec }} {{ $key | quote }}: {{ if typeIs "string" $value }} {{ $value | quote }} {{ else }} {{ $value }} {{ end }}, {{- end }} {{ if .Values.tls.enabled }}"pgParameters": {{- $pgParameters := .Values.pgParameters -}}{{ $all := set $pgParameters "ssl" "on" }}{{ $all := set $all "ssl_cert_file" "/certs/serverCrt.crt" }} {{ $all := set $all "ssl_key_file" "/certs/serverKey.key" }}{{ $all := set $all "ssl_ca_file" "/certs/rootCa.crt" }}{{ toJson $all }} {{ else }}"pgParameters": {{- $pgParameters := .Values.pgParameters -}}{{ $all := set $pgParameters "ssl" "off" }}{{ $all := set $all "ssl_cert_file" nil }} {{ $all := set $all "ssl_key_file" nil }}{{ $all := set $all "ssl_ca_file" nil }}{{ toJson $all }}{{ end}}}'
           resources:
             {{- toYaml .Values.job.autoUpdateClusterSpec.resources | nindent 12 }}
+          {{- with .Values.job.autoUpdateClusterSpec.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
 {{ end }}

--- a/templates/keeper-statefulset.yaml
+++ b/templates/keeper-statefulset.yaml
@@ -32,9 +32,9 @@ spec:
 {{- end }}
       serviceAccountName: {{ template "stolon.serviceAccountName" . }}
       terminationGracePeriodSeconds: 10
-{{- if .Values.keeper.fsGroup }}
+{{- with .Values.keeper.podSecurityContext }}
       securityContext:
-        fsGroup: {{ .Values.keeper.fsGroup }}
+        {{- toYaml . | nindent 8 }}
 {{- end }}
 {{- if .Values.image.pullSecrets }}
       imagePullSecrets:
@@ -126,6 +126,10 @@ spec:
 {{- end }}
           resources:
 {{ toYaml .Values.keeper.resources | indent 12 }}
+{{- with .Values.keeper.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+{{- end }}
           volumeMounts:
 {{- if .Values.shmVolume.enabled }}
           - name: dshm

--- a/templates/proxy-deployment.yaml
+++ b/templates/proxy-deployment.yaml
@@ -33,6 +33,10 @@ spec:
 {{- if .Values.image.pullSecrets }}
       imagePullSecrets:
 {{ toYaml .Values.image.pullSecrets | indent 8 }}
+{{- with .Values.proxy.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+{{- end }}
 {{- end }}
       containers:
         - name: {{ .Chart.Name }}
@@ -75,6 +79,10 @@ spec:
 {{- end }}
           resources:
 {{ toYaml .Values.proxy.resources | indent 12 }}
+{{- with .Values.proxy.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+{{- end }}
           readinessProbe:
             tcpSocket:
               port: {{ .Values.ports.stolon.containerPort }}

--- a/templates/sentinel-deployment.yaml
+++ b/templates/sentinel-deployment.yaml
@@ -34,6 +34,10 @@ spec:
 {{- if .Values.image.pullSecrets }}
       imagePullSecrets:
 {{ toYaml .Values.image.pullSecrets | indent 8 }}
+{{- with .Values.sentinel.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+{{- end }}
 {{- end }}
       containers:
         - name: {{ .Chart.Name }}
@@ -74,6 +78,10 @@ spec:
 {{- end }}
           resources:
 {{ toYaml .Values.sentinel.resources | indent 12 }}
+{{- with .Values.sentinel.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+{{- end }}
 {{- with .Values.sentinel.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}

--- a/values.yaml
+++ b/values.yaml
@@ -93,18 +93,27 @@ job:
   autoCreateCluster:
     enabled: true
     resources: {}
+    podSecurityContext: {}
+    securityContext: {}
     initContainers:
       resources: {}
+      securityContext: {}
   initdbScripts:
     enabled: true
     resources: {}
+    podSecurityContext: {}
+    securityContext: {}
     initContainers:
       resources: {}
+      securityContext: {}
   autoUpdateClusterSpec:
     enabled: true
     resources: {}
+    podSecurityContext: {}
+    securityContext: {}
     initContainers:
       resources: {}
+      securityContext: {}
   annotations: {}
 
 clusterSpec: {}
@@ -127,8 +136,9 @@ keeper:
   replicaCount: 2
   annotations: {}
   resources: {}
+  podSecurityContext: {}
+  securityContext: {}
   priorityClassName: ""
-  fsGroup: ""
   service:
     type: ClusterIP
     annotations: {}
@@ -156,6 +166,8 @@ proxy:
   replicaCount: 2
   annotations: {}
   resources: {}
+  podSecurityContext: {}
+  securityContext: {}
   priorityClassName: ""
   service:
     type: ClusterIP
@@ -186,6 +198,8 @@ sentinel:
   replicaCount: 2
   annotations: {}
   resources: {}
+  podSecurityContext: {}
+  securityContext: {}
   priorityClassName: ""
   nodeSelector: {}
   affinity: {}


### PR DESCRIPTION
* Introduce Security Context for Pods, Containers and Init Containers for all Jobs, StatefulSets and Deployments.
* Remove fsGroup Option from the keeper, because this can now also be set via the regular Security Context.