### PR TITLE
Make actual use of the job.initdbScripts.enabled Value

### DIFF
--- a/templates/hooks/init-db-job.yaml
+++ b/templates/hooks/init-db-job.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.job.initdbScripts.enabled }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -77,4 +78,5 @@ spec:
           command: ['dockerize', '-timeout', '30s', '-wait', 'tcp://{{ template "stolon.fullname" . }}-proxy:5432']
           resources:
             {{- toYaml .Values.job.initdbScripts.initContainers.resources | nindent 12 }}
+{{- end }}
 {{- end }}


### PR DESCRIPTION
Currently this value is ignored and the job is enabled and disabled, if scripts are given to run. Since there is a enabled flag in the values, it should be used.